### PR TITLE
 Use directory name instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,20 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - uses: ./
+      - name: Basic usage
+        uses: ./
         with:
           connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
           name: 'azblob-download-artifact'
 
       - name: Confirm
         run: |
-          ls
-          cat Download.txt
-          cat Upload.txt
+          test -d azblob-download-artifact
+          test -f azblob-download-artifact/Hello.txt
+          test -f azblob-download-artifact/World.txt
 
-      - uses: ./
+      - name: Download to a specific path
+        uses: ./
         with:
           connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
           name: 'azblob-download-artifact'
@@ -28,7 +30,6 @@ jobs:
 
       - name: Confirm
         run: |
-          ls
-          ls path/to/download
-          cat Download.txt
-          cat Upload.txt
+          test -d path/to/download/azblob-download-artifact
+          test -f path/to/download/azblob-download-artifact/Hello.txt
+          test -f path/to/download/azblob-download-artifact/World.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
           test -d azblob-download-artifact
           test -f azblob-download-artifact/Hello.txt
           test -f azblob-download-artifact/World.txt
+          echo "-----------------------------------"
+          ls -1v ./
+          echo "-----------------------------------"
+          ls -1v ./azblob-download-artifact
+          echo "-----------------------------------"
 
       - name: Download to a specific path
         uses: ./
@@ -33,3 +38,8 @@ jobs:
           test -d path/to/download/azblob-download-artifact
           test -f path/to/download/azblob-download-artifact/Hello.txt
           test -f path/to/download/azblob-download-artifact/World.txt
+          echo "-----------------------------------"
+          ls -1v ./path/to/download/
+          echo "-----------------------------------"
+          ls -1v ./path/to/download/azblob-download-artifact
+          echo "-----------------------------------"

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,15 @@ inputs:
     description: 'Destination path'
     required: false
     default: '.'
+  container:
+    description: 'Container name'
+    required: false
+    default: 'github-action-artifacts'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - '${{ inputs.container }}'
     - '${{ inputs.name }}'
     - '${{ inputs.path }}'
   env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+AZ_CONTAINER=$1; shift
 AZ_NAME=$1; shift
 AZ_PATH=$1; shift
 
-mkdir -p "$AZ_PATH"
-az storage blob download-batch -d "$AZ_PATH" -s "$AZ_NAME"
+mkdir -p "$AZ_PATH/$AZ_NAME"
+az storage blob download-batch -d "$AZ_PATH" -s "$AZ_CONTAINER" --pattern "$AZ_NAME/*"


### PR DESCRIPTION
While Azure Blob Storage has strict limitation for container name, use directory instead.